### PR TITLE
Avoid use of ES6 class getter to fix IE8

### DIFF
--- a/modules/locations/TestLocation.js
+++ b/modules/locations/TestLocation.js
@@ -11,10 +11,7 @@ class TestLocation {
     this.history = history || [];
     this.listeners = [];
     this._updateHistoryLength();
-  }
-
-  get needsDOM() {
-    return false;
+    this.needsDOM = false;
   }
 
   _updateHistoryLength() {


### PR DESCRIPTION
This should be the same as this: https://github.com/rackt/react-router/pull/1143/files
